### PR TITLE
Fix/route search

### DIFF
--- a/.changeset/two-dryers-warn.md
+++ b/.changeset/two-dryers-warn.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-router": patch
+---
+
+Fix infinite recursion during route search

--- a/src/RouterUtils.ts
+++ b/src/RouterUtils.ts
@@ -65,7 +65,7 @@ export class RouterUtils {
     const exactMatch = routes.find(route => route.path === path);
     if (exactMatch && exactMatch.render) return exactMatch
     else if (exactMatch && exactMatch.children && exactMatch.children.length > 0) {
-      return RouterUtils.findRoute(RouterUtils.getChildPath(path, exactMatch), routes);
+      return RouterUtils.findRoute(RouterUtils.getChildPath(path, exactMatch), exactMatch.children);
     } else if(exactMatch) return exactMatch;
 
     for (const route of routes) {

--- a/src/RouterUtils.ts
+++ b/src/RouterUtils.ts
@@ -64,7 +64,9 @@ export class RouterUtils {
     // First, try to find an exact match
     const exactMatch = routes.find(route => route.path === path);
     if (exactMatch && exactMatch.render) return exactMatch
-    else if (exactMatch) return RouterUtils.findRoute(RouterUtils.getChildPath(path, exactMatch), routes);
+    else if (exactMatch && exactMatch.children && exactMatch.children.length > 0) {
+      return RouterUtils.findRoute(RouterUtils.getChildPath(path, exactMatch), routes);
+    } else if(exactMatch) return exactMatch;
 
     for (const route of routes) {
       if (path.startsWith(route.path) && route.children && route.children.length > 0) {


### PR DESCRIPTION
This pull request addresses a bug in the `@ayu-sh-kr/dota-router` package by fixing an issue that caused infinite recursion during route searches. The changes ensure safer handling of routes with children in the `RouterUtils` class.

### Bug Fixes:

* [`.changeset/two-dryers-warn.md`](diffhunk://#diff-ebdca4a8c4a0ba1b78b4cdbedcc858fa7893957c3128ccf0a21711261e38bf29R1-R5): Added a patch note for the `@ayu-sh-kr/dota-router` package, describing the fix for infinite recursion during route search.

* [`src/RouterUtils.ts`](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L67-R69): Updated the `findRoute` logic in the `RouterUtils` class to check for the presence of children in a route before attempting to recursively search for child paths. This prevents infinite recursion when a route exists but has no children.