### PR TITLE
Fix/types

### DIFF
--- a/.changeset/violet-hoops-repeat.md
+++ b/.changeset/violet-hoops-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-router": patch
+---
+
+Fix type not declared issue with rollup build config

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,17 +15,31 @@ const config = [
         format: 'es',
       },
     ],
-    external: ['reflect-metadata'],
+    external: ['reflect-metadata', '@ayu-sh-kr/dota-core'],
     plugins: [
       resolve(),
-      typescript({tsconfig: './tsconfig.json'}),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+      }),
     ],
   },
   {
-    // Bundle declaration files
     input: 'src/index.ts',
-    output: [{file: 'dist/index.d.ts', format: 'es'}],
-    plugins: [dts()],
+    output: {
+      file: 'dist/index.d.ts',
+      format: 'es',
+    },
+    plugins: [
+      dts({
+        respectExternal: true,
+        compilerOptions: {
+          preserveSymlinks: false,
+          paths: { "@dota/*": ["./src/*"] },
+          baseUrl: "."
+        }
+      })
+    ],
   },
 ];
 


### PR DESCRIPTION
This pull request addresses issues with the Rollup build configuration for the `@ayu-sh-kr/dota-router` package, including fixing type declaration problems and improving the handling of external dependencies and TypeScript configuration. 

### Rollup build configuration updates:

* [`.changeset/violet-hoops-repeat.md`](diffhunk://#diff-52b4e50bda7c3ac415086a738a25d29a47092c91c26522bf2ca02da5b654b594R1-R5): Added a patch change entry for `@ayu-sh-kr/dota-router` to document the fix for the type declaration issue in the Rollup build configuration.
* `rollup.config.mjs`:  
  - Added `@ayu-sh-kr/dota-core` to the `external` dependencies to ensure proper handling of imports.  
  - Updated the TypeScript plugin configuration to disable declaration file generation during the main build process by setting `declaration: false`.  
  - Enhanced the declaration file bundling process by configuring the `dts` plugin with options like `respectExternal`, `preserveSymlinks`, and `paths` to improve compatibility and resolve path aliases.