### PR TITLE
Fix/type issue

### DIFF
--- a/.changeset/khaki-regions-love.md
+++ b/.changeset/khaki-regions-love.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-router": patch
+---
+
+fix type issue down stream

--- a/src/RouterUtils.ts
+++ b/src/RouterUtils.ts
@@ -1,5 +1,5 @@
 import {NavigationOption, RenderConfig, RouteConfig, RouterService} from "@dota/Types";
-import {BaseElement, ComponentConfig} from "@ayu-sh-kr/dota-core";
+import {ComponentConfig} from "@ayu-sh-kr/dota-core";
 import 'reflect-metadata';
 import {DomNavigationRouter} from "@dota/dom-navigation.router";
 import {DomHistoryRouter} from "@dota/dom-history.router";
@@ -47,7 +47,7 @@ export class RouterUtils {
    * @param route - The route configuration to check against.
    * @returns The child path as a string or '/' if not found.
    */
-  static getChildPath<T extends BaseElement>(path: string, route: RouteConfig<T>) {
+  static getChildPath<T extends HTMLElement>(path: string, route: RouteConfig<T>) {
     return path.substring(route.path.length) || '/';
   }
 
@@ -94,7 +94,7 @@ export class RouterUtils {
    * // Non-existent path with valid parent prefix
    * findRoute("/users/unknown", routes) -> May return UsersComponent as fallback
    */
-  static findRoute<T extends BaseElement>(path: string, routes: RouteConfig<T>[]): RouteConfig<T> | undefined {
+  static findRoute<T extends HTMLElement>(path: string, routes: RouteConfig<T>[]): RouteConfig<T> | undefined {
     // Phase 1: Exact Match Phase
     const exactMatch = routes.find(route => route.path === path);
     if (exactMatch) return exactMatch;
@@ -136,7 +136,7 @@ export class RouterUtils {
    * @param config - The configuration object containing the path, routes, options, and router instance.
    * @returns void
    */
-  static render<T extends BaseElement>(config: RenderConfig<T>): void {
+  static render<T extends HTMLElement>(config: RenderConfig<T>): void {
     const {path, routes, options} = config;
     const router = config.router as RouterService<T>;
     if (path === '/error') {
@@ -183,7 +183,7 @@ export class RouterUtils {
    * @param options - Optional navigation options.
    * @returns void
    */
-  static route(router: RouterService<BaseElement>, path: string, options?: NavigationOption) {
+  static route(router: RouterService<HTMLElement>, path: string, options?: NavigationOption) {
     // Normalize the path to ensure it starts with a slash
     const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,12 +1,10 @@
-import {BaseElement} from "@ayu-sh-kr/dota-core";
-
 /**
  * RouterService interface defines the methods that a router service should implement.
  * It includes an init method to initialize the router and a render method to render the appropriate component based on the current path.
  *
  * @template T - The type of the component that the router will render.
  */
-export interface RouterService<T extends BaseElement> {
+export interface RouterService<T extends HTMLElement> {
 
   readonly routes: RouteConfig<T>[];
   readonly errorRoute: RouteConfig<T>;
@@ -23,7 +21,7 @@ export interface RouterService<T extends BaseElement> {
   init(): void;
 }
 
-export type RouteConfig<T extends BaseElement> = {
+export type RouteConfig<T extends HTMLElement> = {
   path: string;
   component: new () => T;
   default?: boolean;
@@ -35,7 +33,7 @@ export type NavigationOption = {
   [key: string]: string;
 }
 
-export type RenderConfig<T extends BaseElement> = {
+export type RenderConfig<T extends HTMLElement> = {
   path: string;
   routes: RouteConfig<T>[];
   options?: NavigationOption;

--- a/src/dom-navigation.router.ts
+++ b/src/dom-navigation.router.ts
@@ -1,8 +1,7 @@
-import {BaseElement} from "@ayu-sh-kr/dota-core";
 import {NavigationOption, RouteConfig, RouterService} from "@dota/Types";
 import {RouterUtils} from "@dota/RouterUtils";
 
-export class DomNavigationRouter<T extends BaseElement> implements RouterService<T> {
+export class DomNavigationRouter<T extends HTMLElement> implements RouterService<T> {
 
   public readonly routes: RouteConfig<T>[]
   public readonly errorRoute: RouteConfig<T>;


### PR DESCRIPTION
This pull request makes a series of updates to the `@ayu-sh-kr/dota-router` package, primarily addressing type adjustments and cleaning up unused imports. The most significant change involves replacing the `BaseElement` type with the standard `HTMLElement` type across various files to improve compatibility and maintainability.

### Type Adjustments:
* Replaced `BaseElement` with `HTMLElement` in the `RouterUtils` class methods (`getChildPath`, `findRoute`, `render`, and `route`) to standardize the type used for route configurations and components. (`[[1]](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L50-R50)`, `[[2]](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L97-R97)`, `[[3]](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L139-R139)`, `[[4]](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L186-R186)`)
* Updated the `RouterService` interface and related types (`RouteConfig`, `RenderConfig`) to use `HTMLElement` instead of `BaseElement`. (`[[1]](diffhunk://#diff-f373d4637e1a9247d14a4b89b4d4592f4ddb59ba8bca1101edcc4dcd01e4955fL1-R7)`, `[[2]](diffhunk://#diff-f373d4637e1a9247d14a4b89b4d4592f4ddb59ba8bca1101edcc4dcd01e4955fL26-R24)`, `[[3]](diffhunk://#diff-f373d4637e1a9247d14a4b89b4d4592f4ddb59ba8bca1101edcc4dcd01e4955fL38-R36)`)
* Modified the `DomNavigationRouter` class to align with the `RouterService` changes by using `HTMLElement` as the generic type. (`[src/dom-navigation.router.tsL1-R4](diffhunk://#diff-87d32040c6a74b43ffa609c5a21fb925af6eef572eddb2446d7a8c17589ba3dbL1-R4)`)

### Code Cleanup:
* Removed the unused `BaseElement` import from `RouterUtils.ts`, `Types.ts`, and `dom-navigation.router.ts` to eliminate unnecessary dependencies. (`[[1]](diffhunk://#diff-fb0fbc0e6c8113736823051a886781985231e9638f4fac2aec57ef2bd98bade9L2-R2)`, `[[2]](diffhunk://#diff-f373d4637e1a9247d14a4b89b4d4592f4ddb59ba8bca1101edcc4dcd01e4955fL1-R7)`, `[[3]](diffhunk://#diff-87d32040c6a74b43ffa609c5a21fb925af6eef572eddb2446d7a8c17589ba3dbL1-R4)`)

### Miscellaneous:
* Added a changeset file to document the patch-level update for fixing downstream type issues. (`[.changeset/khaki-regions-love.mdR1-R5](diffhunk://#diff-b15280541a9dc88d71a8bc5a6e6826d9d077d1386e7a4023c7513ff23a595e61R1-R5)`)