### PR TITLE
Fix/component routing

### DIFF
--- a/.changeset/lemon-dogs-enter.md
+++ b/.changeset/lemon-dogs-enter.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-router": patch
+---
+
+added feature to enable routing via decorators and components

--- a/src/DotaRouterService.ts
+++ b/src/DotaRouterService.ts
@@ -44,6 +44,15 @@ export class DotaRouterService<T extends Router<HTMLElement>> implements RouterS
     )
   }
 
+  /**
+   * Requires a router instance and a list of components to create a RouterService instance.
+   * The components are processed to generate the routing configuration.
+   *
+   * This method is a factory method that helps create a RouterService instance.
+   * @param config - The configuration object containing the router instance and its components.
+   * @throws Error if components are not provided in the configuration.
+   * @returns A RouterService instance.
+   */
   static fromComponents<T extends Router<HTMLElement>>(config: DefaultRouterConfig<T>): RouterService<T> {
     if (!config.components) throw Error('Elements are required to create a RouterService instance');
     const routes = RouterUtils.prepareConfig(config.components);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export {RouterUtils} from "@dota/RouterUtils";
 export {DomNavigationRouter} from "@dota/dom-navigation.router";
 export {DomHistoryRouter} from "@dota/dom-history.router";
 export {DotaRouterService} from "@dota/DotaRouterService";
+export {Route} from "@dota/route.decorator";
 export * from "@dota/Types";


### PR DESCRIPTION
This pull request introduces a new feature that enables routing via decorators and components, and exposes new exports to support this functionality. The main changes include the addition of a factory method for creating router services from components, and the export of the `Route` decorator for external use.

**New Routing Feature:**

* Added a feature to enable routing via decorators and components, making it easier to define routes in a declarative way. (.changeset/lemon-dogs-enter.md)

**API Enhancements:**

* Added a static factory method `fromComponents` to `DotaRouterService`, allowing users to create a `RouterService` instance from a router and a list of components. This method processes components to generate the routing configuration and throws an error if components are missing. (`src/DotaRouterService.ts`)
* Exported the `Route` decorator from the main entry point, enabling consumers to use route decorators in their applications. (`src/index.ts`)